### PR TITLE
mailto links

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
                     <p>Cameron Holmes:</p>
                     <p>Born and raised in Nashville, Tennessee. I am 17 years old and play basketball. I love learning about Earth and Space Science!</p>
                     <p>holmescm2612@aguafria.org</p>
-                    <a href="https://mail.google.com/mail/u/0/">
+                    <a href="mailto:holmescm2612@aguafria.org">
                     <button>Contact!</button>
                     </a>
                 </div>
@@ -37,7 +37,7 @@
                     <p>Hollyn Bertucci:</p>
                     <p> Born and raised in Arizona. I am 16 years old and do cheer. I go to Millennium High school where I love learning about science.</p>
                     <p>reesend2700@aguafria.org</p>
-                    <a href="https://mail.google.com/mail/u/0/">
+                    <a href="mailto:reesend2700@aguafria.org">
                     <button>Contact!</button>
                     </a>
                 </div>
@@ -47,7 +47,7 @@
                     <p>Nathan Reese:</p>
                     <p>Born and raised in Bakersfeild California, im 16 years old and love to skate and draw. I also like hanging out with friends.</p>
                     <p>Bertuccihb2683@aguafria.org</p>
-                    <a href="https://mail.google.com/mail/u/0/" target="_blank">
+                    <a href="mailto:Bertuccihb2683@aguafria.org" target="_blank">
                     <button>Contact!</button>
                     </a>
                 </div>
@@ -57,7 +57,7 @@
                     <p>Michael Rodriguez:</p>
                     <p>Born and raised in Yuma Arizona, I am 16 years old and love to code and make web pages. I love learning about Earth and Space Science.</p>
                     <p>rodriguezm2684@aguafria.org</p>
-                    <a href="https://mail.google.com/mail/u/0/">
+                    <a href="mailto:rodriguezm2684@aguafria.org">
                     <button>Contact!</button>
                     </a>
                 


### PR DESCRIPTION
Coverts all your links to gmail into mailto: links, rather than just opening up gmail. This will open up whatever the user uses for their email (outlook, gmail, apple mail, etc.) with the email already in place. Nice project btw.